### PR TITLE
chore(deps): bump minor upgrade and pin `colors`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "winston"
   ],
   "dependencies": {
-    "colors": "~1.0.3",
+    "colors": "1.4.0",
     "eyes": "~0.1.8",
     "winston": "0.8.x"
   },


### PR DESCRIPTION
More on this here change: https://snyk.io/blog/open-source-maintainer-pulls-the-plug-on-npm-packages-colors-and-faker-now-what

(I know that the current semver range (`~1.0.3`) does not cover the bad version of `colors` package)